### PR TITLE
To fix the docker image name which is pushed to GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build and Deploy
 
 on:
     push:
-      tags:
-        - '*'
+     # tags:
+        #- '*'
 
 jobs:
   ghcr-build-and-deploy:
@@ -57,9 +57,10 @@ jobs:
         id: image_vars
         run: |
           REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
+          SHORT_SHA=$(git rev-parse --short HEAD)
           TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
           IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
-          IMAGE_TAG=${TAG_LOWER}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,10 +57,10 @@ jobs:
         id: image_vars
         run: |
           REPO_LOWER=$(echo "${GITHUB_REPOSITORY}" | tr '[:upper:]' '[:lower:]')
-          SHORT_SHA=$(git rev-parse --short HEAD)
+          SHORT_SHA=$(git rev-parse HEAD | cut -c1-7)
           TAG_LOWER=$(echo "${GITHUB_REF_NAME}" | tr '[:upper:]' '[:lower:]')
           IMAGE_NAME=${{ env.REGISTRY }}/${REPO_LOWER}
-          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}
+          IMAGE_TAG=${TAG_LOWER}_${SHORT_SHA}_${GITHUB_RUN_NUMBER}
           echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,8 @@ name: Build and Deploy
 
 on:
     push:
-     # tags:
-        #- '*'
+      tags:
+        - '*'
 
 jobs:
   ghcr-build-and-deploy:


### PR DESCRIPTION
This PR fixes the docker image tag name where the commit SHA was not being added previously.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Enhance the Docker image tagging strategy by including a shortened commit SHA and the GitHub run number in the image tag.

### Why are these changes being made?

Previously, the Docker image tagging only used the branch name, potentially leading to tag conflicts if multiple builds were triggered from the same branch. This change ensures that each image tag is unique by incorporating both the shortened commit SHA and the GitHub run number, thus avoiding such conflicts and providing more traceability for each image build.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->