### PR TITLE
Issue #SBCOSS-424: Vulnerability and dependency conflict fixes and test fixes

### DIFF
--- a/course-mw/course-actors-common/pom.xml
+++ b/course-mw/course-actors-common/pom.xml
@@ -120,19 +120,19 @@
 		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz</artifactId>
-			<version>2.2.1</version>
+			<version>2.3.2</version>
 		</dependency>
 		<dependency>
 			<groupId>org.quartz-scheduler</groupId>
 			<artifactId>quartz-jobs</artifactId>
-			<version>2.2.1</version>
+			<version>2.3.2</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.postgresql/postgresql -->
 		<dependency>
 			<groupId>org.postgresql</groupId>
 			<artifactId>postgresql</artifactId>
-			<version>42.1.4</version>
+			<version>42.2.28</version>
 		</dependency>
 		<dependency>
 			<groupId>com.lmax</groupId>
@@ -149,7 +149,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>4.10.0</version>
+			<version>3.12.13</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/course-mw/enrolment-actor/pom.xml
+++ b/course-mw/enrolment-actor/pom.xml
@@ -73,6 +73,12 @@
       <artifactId>cassandra-unit</artifactId>
       <version>3.11.2.0</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.typesafe.akka</groupId>

--- a/course-mw/sunbird-util/sunbird-cache-utils/pom.xml
+++ b/course-mw/sunbird-util/sunbird-cache-utils/pom.xml
@@ -14,7 +14,7 @@
       <dependency>
          <groupId>org.redisson</groupId>
          <artifactId>redisson</artifactId>
-         <version>3.2.0</version>
+         <version>3.22.0</version>
          <exclusions>
             <exclusion>
                <groupId>net.bytebuddy</groupId>
@@ -128,6 +128,40 @@
                   <goals>
                      <goal>report</goal>
                   </goals>
+               </execution>
+            </executions>
+         </plugin>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-shade-plugin</artifactId>
+            <version>3.2.4</version>
+            <executions>
+               <execution>
+                  <phase>package</phase>
+                  <goals>
+                     <goal>shade</goal>
+                  </goals>
+                  <configuration>
+                     <filters>
+                        <filter>
+                           <artifact>*:*</artifact>
+                           <excludes>
+                              <exclude>META-INF/*.SF</exclude>
+                              <exclude>META-INF/*.DSA</exclude>
+                              <exclude>META-INF/*.RSA</exclude>
+                           </excludes>
+                        </filter>
+                     </filters>
+                     <relocations>
+                        <relocation>
+                           <pattern>io.netty</pattern>
+                           <shadedPattern>org.sunbird.shaded.io.netty</shadedPattern>
+                        </relocation>
+                     </relocations>
+                     <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                     </transformers>
+                  </configuration>
                </execution>
             </executions>
          </plugin>

--- a/course-mw/sunbird-util/sunbird-cache-utils/src/main/java/org/sunbird/redis/RedisConnectionManager.java
+++ b/course-mw/sunbird-util/sunbird-cache-utils/src/main/java/org/sunbird/redis/RedisConnectionManager.java
@@ -53,7 +53,7 @@ public class RedisConnectionManager {
 
     Config config = new Config();
     SingleServerConfig singleServerConfig = config.useSingleServer();
-    singleServerConfig.setAddress(host + ":" + port);
+    singleServerConfig.setAddress("redis://" + host + ":" + port);
     singleServerConfig.setConnectionPoolSize(poolsize);
     config.setCodec(new StringCodec());
     client = Redisson.create(config);

--- a/course-mw/sunbird-util/sunbird-cassandra-utils/pom.xml
+++ b/course-mw/sunbird-util/sunbird-cassandra-utils/pom.xml
@@ -74,6 +74,12 @@
 			<artifactId>cassandra-unit</artifactId>
 			<version>3.11.2.0</version>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>*</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.powermock</groupId>

--- a/course-mw/sunbird-util/sunbird-platform-core/common-util/pom.xml
+++ b/course-mw/sunbird-util/sunbird-platform-core/common-util/pom.xml
@@ -88,6 +88,17 @@
             <groupId>org.apache.velocity</groupId>
             <artifactId>velocity-tools</artifactId>
             <version>2.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/javax.mail/javax.mail-api -->
         <dependency>
@@ -129,6 +140,17 @@
             <groupId>org.apache.poi</groupId>
             <artifactId>poi-ooxml</artifactId>
             <version>3.17</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.xmlbeans</groupId>
+                    <artifactId>xmlbeans</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.xmlbeans</groupId>
+            <artifactId>xmlbeans</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -219,6 +241,14 @@
             <version>${CLOUD_STORE_VERSION}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.avro</groupId>
+                    <artifactId>avro</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.sun.jersey</groupId>
                     <artifactId>jersey-core</artifactId>
                 </exclusion>
@@ -247,6 +277,16 @@
                     <artifactId>snakeyaml</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>3.7.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>1.11.4</version>
         </dependency>
 <!--        Downgrading the snakeyaml from 2.0 to 1.33, due to CassandraDACImplTest test cases was failing. -->
         <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -79,6 +79,17 @@
 			<artifactId>play-netty-server_${scala.major.version}</artifactId>
 			<version>${play2.version}</version>
 			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>io.netty</groupId>
+					<artifactId>netty-codec-http</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>io.netty</groupId>
+			<artifactId>netty-codec-http</artifactId>
+			<version>4.1.44.Final</version>
 		</dependency>
 <!--		<dependency>-->
 <!--			<groupId>io.netty</groupId>-->


### PR DESCRIPTION
## Summary
This PR applies security vulnerability fixes by updating dependencies to patched versions and aligning libraries across modules to ensure compliance, stability, and compatibility also it esolves dependency conflicts and test failures by updating Redisson, adjusting its configuration usage, managing transitive dependencies with the Maven Shade Plugin, and aligning test dependencies.

## Changes
- Removed `Netty` dependency from `cassandra-unit` (test scope) to fix conflicts causing test failures.
- Upgraded `Redisson` from `3.2.0` to `3.22.0` to fix the critical vulnerability:
  - Updated config usage from `setAddress(host + ":" + port)` to `setAddress("redis://" + host + ":" + port)`.
- Added **Maven Shade Plugin** to `sunbird-cache-utils` to manage Redisson’s transitive Netty dependency.
- Downgraded `mockwebserver` from `4.10.0` to `3.12.13` to resolve failing tests.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Upgrade multiple dependencies across various modules to address vulnerabilities, resolve dependency conflicts, and update testing configurations, including the addition of exclusion rules and adjustments that ensure compatibility.

### Why are these changes being made?

These changes are required to mitigate security vulnerabilities associated with outdated dependencies, specifically aiming to align dependencies to compatible versions and improve both functionality and security of the system. Additional configuration, such as exclusions in dependency management, ensures smooth integration and operation of the software modules.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->